### PR TITLE
Handle pathnames more robustly.

### DIFF
--- a/epubdiff
+++ b/epubdiff
@@ -5,6 +5,7 @@ import re
 import shutil
 import sys
 import zipfile
+import tempfile
 
 from pyquery import PyQuery as pq
 from subprocess import call
@@ -152,30 +153,30 @@ if __name__ == '__main__':
         base2 = os.path.splitext(os.path.basename(file2))[0]
 
     # Output paths
-    temp_dir1 = '_tmp1'
-    temp_dir2 = '_tmp2'
-    output1 = '{}/{}.txt'.format(temp_dir1, base1)
-    output2 = '{}/{}.txt'.format(temp_dir2, base2)
+    with tempfile.TemporaryDirectory() as temp_dir1:
+        with tempfile.TemporaryDirectory() as temp_dir2:
+            output1 = '{}/{}.txt'.format(temp_dir1, base1)
+            output2 = '{}/{}.txt'.format(temp_dir2, base2)
 
-    # Unzip EPUBs
-    unzip_epub(file1, temp_dir1)
-    unzip_epub(file2, temp_dir2)
+            # Unzip EPUBs
+            unzip_epub(file1, temp_dir1)
+            unzip_epub(file2, temp_dir2)
 
-    # Get manifest
-    files1 = get_file_list(temp_dir1)
-    files2 = get_file_list(temp_dir2)
+            # Get manifest
+            files1 = get_file_list(temp_dir1)
+            files2 = get_file_list(temp_dir2)
 
-    # Concatenate
-    html1 = concatenate_html(files1)
-    html2 = concatenate_html(files2)
+            # Concatenate
+            html1 = concatenate_html(files1)
+            html2 = concatenate_html(files2)
 
-    # Save out
-    save_html(html1, output1)
-    save_html(html2, output2)
+            # Save out
+            save_html(html1, output1)
+            save_html(html2, output2)
 
-    # Diff
-    call(['diff', output1, output2])
+            # Diff
+            call(['diff', output1, output2])
 
-    # Cleanup
-    clean_directory(temp_dir1)
-    clean_directory(temp_dir2)
+            # Cleanup
+            clean_directory(temp_dir1)
+            clean_directory(temp_dir2)

--- a/epubdiff
+++ b/epubdiff
@@ -148,8 +148,8 @@ if __name__ == '__main__':
         file1 = sys.argv[1]
         file2 = sys.argv[2]
 
-        base1 = os.path.splitext(file1)[0]
-        base2 = os.path.splitext(file2)[0]
+        base1 = os.path.splitext(os.path.basename(file1))[0]
+        base2 = os.path.splitext(os.path.basename(file2))[0]
 
     # Output paths
     temp_dir1 = '_tmp1'


### PR DESCRIPTION
These changes are intended to make the script's handling of filenames and paths more robust in two ways:

- When getting the name of an input file to use as the base for the intermediate-output file, use only its "basename", ignoring its path. This fixes #1.
- Use the `tempfile` library to create temporary directories, instead of hard-coding `_tmp1` and `_tmp2` in the current directory.

It seems to me that the temporary directories the `tempfile` library provides are probably cleaned up automatically by it at the end of their `with` blocks, but I left the `clean_directory` calls in anyway. 

And I also suspect that there is some better way of joining directory and file names than string formatting, which seems fragile (in the presence of special characters, perhaps?), but that was a bit beyond my Python dabbling capacity just yet.